### PR TITLE
NullSafety版本代码错误导致android状态栏高度一直是0

### DIFF
--- a/android/src/main/kotlin/io/flutter/embedding/android/ThrioFlutterView.java
+++ b/android/src/main/kotlin/io/flutter/embedding/android/ThrioFlutterView.java
@@ -546,7 +546,7 @@ public class ThrioFlutterView extends FrameLayout implements MouseCursorPlugin.M
                         : insets.getSystemWindowInsetLeft();
 
         // Bottom system inset (keyboard) should adjust scrollable bottom edge (inset).
-        viewportMetrics.viewPaddingTop = 0;
+        viewportMetrics.viewInsetTop = 0;
         viewportMetrics.viewInsetRight = 0;
         viewportMetrics.viewInsetBottom =
                 navigationBarHidden


### PR DESCRIPTION
thrio: 2.0.7
flutter: 2.0.6